### PR TITLE
Trigger & Handle CUD events

### DIFF
--- a/auth/change_role_handler.go
+++ b/auth/change_role_handler.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ChangeRole struct {
+	EventCh chan interface{}
 }
 
 func (h *ChangeRole) Handle(w http.ResponseWriter, r *http.Request) {
@@ -34,4 +35,15 @@ func (h *ChangeRole) Handle(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "User role updated successfully")
+
+	go func() {
+		h.EventCh <- Event{
+			Name: "role-changed",
+			Payload: map[string]interface{}{
+				"user-id":  publicId,
+				"email":    requestData.Email,
+				"new-role": requestData.NewRole,
+			},
+		}
+	}()
 }

--- a/auth/signup_handler.go
+++ b/auth/signup_handler.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Signup struct {
+	EventCh chan interface{}
 }
 
 func (h *Signup) Handle(w http.ResponseWriter, r *http.Request) {
@@ -36,4 +37,14 @@ func (h *Signup) Handle(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusCreated)
 	fmt.Fprintf(w, "User created successfully")
+
+	go func() {
+		h.EventCh <- Event{
+			Name: "user-registered",
+			Payload: map[string]interface{}{
+				"role":    user.Role,
+				"user-id": publicId,
+			},
+		}
+	}()
 }

--- a/task_management/cmd/main.go
+++ b/task_management/cmd/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/thekndr/ates/auth_client"
+	"github.com/thekndr/ates/common"
 	"github.com/thekndr/ates/task_management"
 	"github.com/thekndr/ates/task_management/handlers"
 	"github.com/thekndr/ates/task_management/users"
@@ -22,6 +24,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	go mustConsumeFromKafka(ctx, "accounts-stream", func(msg []byte) error {
+		return onAccountChange(msg, workers)
+	})
 	mux := http.NewServeMux()
 
 	mux.HandleFunc(`GET /tasks`, auth_client.WithTokenVerification(
@@ -50,4 +55,49 @@ func main() {
 
 	log.Printf("TaskManagement.Server started at port %d\n", listenPort)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", listenPort), mux))
+}
+
+func onAccountChange(msg []byte, workers *users.Workers) error {
+	type event struct {
+		Name    string                 `json:"event_name"`
+		Context map[string]interface{} `json:"event_context"`
+	}
+	var ev event
+
+	if err := json.Unmarshal(msg, &ev); err != nil {
+		return fmt.Errorf(`failed to decode event: %w`, err)
+	}
+
+	userId, ok := ev.Context["user-id"]
+	if !ok {
+		return fmt.Errorf(`malformed event, user-id missing`)
+	}
+	userIdStr, ok := userId.(string)
+	if !ok {
+		return fmt.Errorf(`malformed event, user-id non-string type`)
+	}
+
+	switch ev.Name {
+	case "user-registered":
+		log.Printf(`user added, id=%s`, userIdStr)
+		_ = workers.Add(
+			userIdStr,
+			// for the sake of simplicity type checking is omit
+			ev.Context["email"].(string),
+		)
+
+	case "role-changed":
+		// for the sake of simplicity type checking is omit
+		newRole := common.Role(ev.Context["new-role"].(string))
+		if !newRole.IsValid() {
+			log.Printf(`invalid role received=%s`, newRole)
+		} else {
+			if common.Role(newRole) != common.WorkerRole {
+				_ = workers.Remove(userIdStr)
+				log.Printf(`non-worker user removed, id=%s, new-role=%s`, userIdStr, newRole)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Основной масс-кусок кода: #2 
- Этот PR про стриминг CUD-событий
- Основные моменты:
  - `auth` сервис. Формирует `jwt` токен.
  - `task_management` сервис. Требует `token`. Для валидации ходит синхронно в `auth` (c retry-backoff стратегией)
- CUD
  - `auth` отправляет в `accounts-stream` два вида событий: "создан аккаунт" и "роль аккаунта изменена"
  - `task_management` на основе `account-stream` воссоздает базу исполнителей задач (`Workers`). База исполнителей in-memory: на каждом старте - воссоздается заново (коммит оффсетов в Kafka отключен). Если новый аккаунт (signup) -- пользователь добавляется. Если меняется роль на не-worker, пользователь удаляется
- События связанные с назначением задач или закрытием сейчас, простоты ради, не создают никаких других событий
- Security-практики, разделение http-обработчиком с бизнес-логикой и прочие более-менее адекватные практики кодирования подразумеваются, но в большинстве случаев осознанно отсутствуют.