### PR TITLE
Follow-up: JiraId support/migration

### DIFF
--- a/accounting/event_handlers/task.go
+++ b/accounting/event_handlers/task.go
@@ -136,6 +136,7 @@ func (h *TaskCompleted) Handle(ev TaskCompletedEvent) error {
 type (
 	TaskCreatedEvent struct {
 		Id          string `json:"id"`
+		JiraId      string `json:"jira_id"`
 		Description string `json:"description"`
 	}
 

--- a/schema_registry/registry.go
+++ b/schema_registry/registry.go
@@ -24,10 +24,14 @@ var (
 	//go:embed resources/tasks/task-created.1.json
 	taskCreatedSchema_1 string
 
+	//go:embed resources/tasks/task-created.2.json
+	taskCreatedSchema_2 string
+
 	globalRegistry = map[string]string{
 		"auth.user-registered.1":   userRegisteredSchema_1,
 		"auth.user-role-changed.1": userRoleChangedSchema_1,
 		"tasks.task-created.1":     taskCreatedSchema_1,
+		"tasks.task-created.2":     taskCreatedSchema_2,
 		"tasks.task-completed.1":   taskCompletedSchema_1,
 		"tasks.task-assigned.1":    taskAssignedSchema_1,
 	}

--- a/schema_registry/resources/tasks/task-created.2.json
+++ b/schema_registry/resources/tasks/task-created.2.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TaskCreatedEvent v2",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["task-created"]
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "version": {
+          "type": "string",
+          "const": "1"
+        }
+      },
+      "required": ["id", "version"],
+      "additionalProperties": false
+    },
+    "context": {
+      "type": "object",
+      "properties": {
+        "assignee-id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "jira-idd": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["assignee-id", "description", "id"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["name", "meta", "context"],
+  "additionalProperties": false
+}

--- a/task_management/cmd/main.go
+++ b/task_management/cmd/main.go
@@ -27,14 +27,16 @@ var (
 
 	authEventVersion  = 1
 	selfEventVersions = event_streaming.EventVersions{
-		"task-created":   1,
+		"task-created":   2,
 		"task-assigned":  1,
 		"task-completed": 1,
 	}
-	selfEventTopic = "task-managements.tasks"
+	selfEventTopic = "task-management.tasks"
 )
 
 func main() {
+	task_management.MustMigrateDB_JiraID(db)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/task_management/tasks_db.go
+++ b/task_management/tasks_db.go
@@ -36,3 +36,10 @@ CREATE TABLE IF NOT EXISTS tasks (
 
 	return db
 }
+
+func MustMigrateDB_JiraID(db *sql.DB) {
+	_, err := db.Exec(`ALTER TABLE tasks ADD COLUMN IF NOT EXISTS jira_id VARCHAR(255)`)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Этот PR про поддержку `jira_id`

Порядок добавления поддержки:
1. Добавить поле `jira_id` в схему БД
2. Добавить новую версию события `task_created` с `jira_id` и зарегистрировать ее в schema registry. `jira_id` должна быть опциональной
3. В клиенте события `task_created` добавить проверку на версию события. В случае новой версии `task_created`, использовать `jira_id` из сообщения
4. Deploy клиента события `task_created`
5. Добавить в http endpoint для создания новой задачи поддержку `jira_id` в схеме входных данных
6. Если для создания новой задачи в http endpoint приходит - использовать его для последующей отправки `task_created` новой версии и добавления в БД
7. В противном случае - выделить `jira_id` из `title`/`description` и использовать его для последующей отправки `task_created` новой версии и добавления в БД
8. Deploy источника события `task_created`
9. По достижению некоего условия, убрать поддержку предыдущей старой версии события `task_created` - из источника события, затем из получателя.
10. Deploy источника и получателя событий
11. (опционально) для старых записей в БД без `jira_id` попробовать выделение `jira_id` из `title`/`description`